### PR TITLE
Add Shopify OAuth API route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Limita
+
+## Shopify OAuth
+
+This project now includes a minimal Next.js setup with an API route at `/pages/api/auth/shopify`. The route performs the OAuth handshake with Shopify and stores shop domains and access tokens in a `shopify_tokens` table in Supabase.
+
+Environment variables required:
+
+```
+SHOPIFY_CLIENT_ID
+SHOPIFY_CLIENT_SECRET
+SHOPIFY_REDIRECT_URI
+SHOPIFY_SCOPES (optional)
+SUPABASE_URL
+SUPABASE_ANON_KEY or SUPABASE_SERVICE_ROLE_KEY
+```
+
+Helpers for calling the Shopify Admin API are available in `lib/shopify.js`.

--- a/lib/shopify.js
+++ b/lib/shopify.js
@@ -1,0 +1,35 @@
+import { getSupabaseClient } from './supabase'
+
+export async function getAccessToken(shop) {
+  const supabase = getSupabaseClient()
+  const { data, error } = await supabase
+    .from('shopify_tokens')
+    .select('access_token')
+    .eq('shop', shop)
+    .single()
+  if (error || !data) {
+    throw new Error(`Token for ${shop} not found`)
+  }
+  return data.access_token
+}
+
+export async function shopifyRestRequest(shop, method, path, body) {
+  const token = await getAccessToken(shop)
+  const url = `https://${shop}/admin/api/2023-07/${path}`
+  const response = await fetch(url, {
+    method,
+    headers: {
+      'X-Shopify-Access-Token': token,
+      'Content-Type': 'application/json'
+    },
+    body: body ? JSON.stringify(body) : undefined
+  })
+  if (!response.ok) {
+    throw new Error(`Shopify REST request failed: ${response.status}`)
+  }
+  return response.json()
+}
+
+export async function shopifyGraphqlRequest(shop, query, variables = {}) {
+  return shopifyRestRequest(shop, 'POST', 'graphql.json', { query, variables })
+}

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js'
+
+export function getSupabaseClient() {
+  const url = process.env.SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY
+  if (!url || !key) {
+    throw new Error('Missing Supabase configuration')
+  }
+  return createClient(url, key)
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "limita",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@supabase/supabase-js": "^2.0.0",
+    "next": "^13.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/pages/api/auth/shopify.js
+++ b/pages/api/auth/shopify.js
@@ -1,0 +1,39 @@
+import { getSupabaseClient } from '../../../lib/supabase'
+
+export default async function handler(req, res) {
+  const { shop, code } = req.query
+
+  if (!shop) {
+    res.status(400).json({ error: 'Missing shop param' })
+    return
+  }
+
+  const clientId = process.env.SHOPIFY_CLIENT_ID
+  const clientSecret = process.env.SHOPIFY_CLIENT_SECRET
+  const redirectUri = process.env.SHOPIFY_REDIRECT_URI
+  const scopes = process.env.SHOPIFY_SCOPES || 'read_products'
+
+  if (!code) {
+    const installUrl = `https://${shop}/admin/oauth/authorize?client_id=${clientId}&scope=${scopes}&redirect_uri=${encodeURIComponent(redirectUri)}`
+    res.redirect(installUrl)
+    return
+  }
+
+  const tokenUrl = `https://${shop}/admin/oauth/access_token`
+  const response = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code })
+  })
+
+  const data = await response.json()
+  if (!response.ok) {
+    res.status(400).json(data)
+    return
+  }
+
+  const supabase = getSupabaseClient()
+  await supabase.from('shopify_tokens').upsert({ shop, access_token: data.access_token })
+
+  res.status(200).json({ success: true })
+}


### PR DESCRIPTION
## Summary
- add Supabase helper
- add Shopify Admin API helper
- implement `/pages/api/auth/shopify` route for OAuth handshake
- document environment variables in README
- add minimal package.json and .gitignore

## Testing
- `npx htmlhint '**/*.html'` *(fails: id-unique, spec-char-escape)*

------
https://chatgpt.com/codex/tasks/task_e_6840286d38f4832ba661baf48d5a2ddf